### PR TITLE
(Alternative) Update stickyfill dependency

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -97,6 +97,7 @@ var Sticker = function (_Component) {
 				window && window.removeEventListener('resize', this.handleResize);
 			}
 			this.unsticky(this.stick);
+			Stickyfill.pause();
 		}
 	}, {
 		key: "componentWillReceiveProps",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "webpack": "^2.6.0"
   },
   "dependencies": {
-    "Stickyfill": "git+https://github.com/seleckis/stickyfill.git",
+    "Stickyfill": "https://github.com/sagansystems/stickyfill",
     "prop-types": "^15.5.10"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -59,6 +59,7 @@ export default class Sticker extends Component {
 			window && window.removeEventListener('resize', this.handleResize);
 		}
 		this.unsticky(this.stick);
+		Stickyfill.pause();
 	}
 	componentWillReceiveProps(nextProps){
 		if(nextProps.forceUpdate !== this.props.forceUpdate){


### PR DESCRIPTION
## WHAT 

Fork react-stickyfill to use our own [stickyfill](https://github.com/sagansystems/stickyfill). Minor changes to make it work with overflowed blocks

## WHY

I had to fork Stickyfill. I needed to fork this to use our own stickyfill

## Context

I think this is the same set of changes as https://github.com/sagansystems/react-stickyfill/pull/1 but without the whitespace and formatting differences.